### PR TITLE
🔀 :: (#31) - ToDo DAO 작성

### DIFF
--- a/feature-domain-main/src/main/java/com/notdo/feature_domain_main/data/local/dao/TodayDoDao.kt
+++ b/feature-domain-main/src/main/java/com/notdo/feature_domain_main/data/local/dao/TodayDoDao.kt
@@ -1,0 +1,22 @@
+package com.notdo.feature_domain_main.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.notdo.feature_domain_main.data.local.entity.ToDoEntity
+import java.util.UUID
+
+@Dao
+interface TodayDoDao {
+
+    @Query("SELECT * FROM Todo WHERE userId = :userId")
+    suspend fun getTodayDo(userId: UUID): ToDoEntity
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTodayDo(todayDo: ToDoEntity)
+
+    @Query("DELETE FROM Todo WHERE id = :id")
+    suspend fun deleteTodayDo(id: UUID)
+
+}


### PR DESCRIPTION
## PR 정보
ToDo DAO를 작성했습니다.

## 작업 내용
- 쿼리문으로 유저 UUID에 따른 투두를 조회하도록 구현했습니다.
- 쿼리문으로 두 Id에 따라 투두를 삭제하도록 구현했습니다.
- insert어노테이션으로 투두을 삽입하도록 구현했습니다.

## 작업 결과
https://github.com/NotDo/NotDo-AOS/blob/740f53f26df3d041dae9991ef732db2948ecaf00/feature-domain-main/src/main/java/com/notdo/feature_domain_main/data/local/dao/TodayDoDao.kt#L10-L22