### PR TITLE
🔀 :: (#37) - 비번찾기의 이메일 인증 페이지 구현

### DIFF
--- a/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailCodeCheckScreen.kt
+++ b/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailCodeCheckScreen.kt
@@ -60,6 +60,7 @@ fun EmailCodeCheckScreen(
             onReSendButtonClick = {
                 countDownTimer.cancel()
                 time = 300
+                isError = false
                 countDownTimer = object : CountDownTimer((time * 1000).toLong(), 1000) {
                     override fun onTick(millisUntilFinished: Long) {
                         time = (millisUntilFinished / 1000).toInt()

--- a/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailCodeCheckScreen.kt
+++ b/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailCodeCheckScreen.kt
@@ -1,12 +1,96 @@
 package com.notdo.feature_ui_findpassword.ui
 
-import androidx.compose.runtime.Composable
+import android.os.CountDownTimer
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
+import com.notdo.util_ui.component.*
 
 @Composable
 fun EmailCodeCheckScreen(
     navController: NavController
 ) {
+    var code by remember {
+        mutableStateOf("")
+    }
 
+    var isError by remember {
+        mutableStateOf(false)
+    }
+
+    var errorMsg by remember {
+        mutableStateOf(" ")
+    }
+
+    var time by remember { mutableStateOf(301) }
+
+    var countDownTimer: CountDownTimer by remember {
+        mutableStateOf(
+            object : CountDownTimer((time * 1000).toLong(), 1000) {
+                override fun onTick(millisUntilFinished: Long) {
+                    time = (millisUntilFinished / 1000).toInt()
+                }
+
+                override fun onFinish() {
+                    isError = true
+                    errorMsg = "인증번호 유효시간이 만료었어요."
+                    time = 0
+                }
+            }.start()
+        )
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        NormalHeader(title = "비밀번호 찾기") {
+            navController.popBackStack()
+        }
+        Spacer(modifier = Modifier.fillMaxHeight(0.05f))
+        GreetingsNotDoView(text = "이메일로 인증번호를 \n보냈어요.")
+        Spacer(modifier = Modifier.fillMaxHeight(0.05f))
+        EmailCodeCheckTextField(
+            text = code,
+            isError = isError,
+            time = time,
+            errorMsg = errorMsg,
+            onReSendButtonClick = {
+                countDownTimer.cancel()
+                time = 300
+                countDownTimer = object : CountDownTimer((time * 1000).toLong(), 1000) {
+                    override fun onTick(millisUntilFinished: Long) {
+                        time = (millisUntilFinished / 1000).toInt()
+                    }
+
+                    override fun onFinish() {
+                        isError = true
+                        errorMsg = "인증번호 유효시간이 만료었어요."
+                        time = 0
+                    }
+                }.start()
+            },
+        ) {
+            code = it
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        NotDoButton(
+            text = "인증",
+            isActivation = code != ""
+        ) {
+            //TODO 이메일 인증 요청 로직
+            //TODO 실패에 따른 예외처리
+        }
+        Spacer(modifier = Modifier.fillMaxHeight(0.06f))
+    }
 }
 

--- a/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailInputScreen.kt
+++ b/feature-ui-findpassword/src/main/java/com/notdo/feature_ui_findpassword/ui/EmailInputScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
+import com.notdo.navigator.NotDoRoutes
 import com.notdo.util_kotlin.format.isEmailPattern
 import com.notdo.util_ui.component.GreetingsNotDoView
 import com.notdo.util_ui.component.NormalHeader
@@ -55,6 +56,7 @@ fun EmailInputScreen(
             isActivation = text != ""
         ) {
             isError = text.isEmailPattern()
+            navController.navigate(NotDoRoutes.FindPassword.EMAIL_CODE_CHECK_SCREEN)
             //TODO 이메일 인증 요청 로직
         }
         Spacer(modifier = Modifier.fillMaxHeight(0.06f))

--- a/feature-ui-signup/src/main/java/com/notdo/feature_ui_signup/ui/EmailCodeCheckScreen.kt
+++ b/feature-ui-signup/src/main/java/com/notdo/feature_ui_signup/ui/EmailCodeCheckScreen.kt
@@ -59,6 +59,7 @@ fun EmailCodeCheckScreen(navController: NavController) {
             onReSendButtonClick = {
                 countDownTimer.cancel()
                 time = 300
+                isError = false
                 countDownTimer = object : CountDownTimer((time * 1000).toLong(), 1000) {
                     override fun onTick(millisUntilFinished: Long) {
                         time = (millisUntilFinished / 1000).toInt()

--- a/util-ui/src/main/java/com/notdo/util_ui/component/GreetingsNotDoView.kt
+++ b/util-ui/src/main/java/com/notdo/util_ui/component/GreetingsNotDoView.kt
@@ -22,6 +22,6 @@ fun GreetingsNotDoView(text: String) {
             modifier = Modifier.fillMaxWidth(0.2f)
         )
         Spacer(modifier = Modifier.size(20.dp))
-        NotDoFont.Hedline1(text = text, fontWeight = FontWeight.SemiBold)
+        NotDoFont.Hedline2(text = text, fontWeight = FontWeight.SemiBold)
     }
 }

--- a/util-ui/src/main/java/com/notdo/util_ui/component/TextField.kt
+++ b/util-ui/src/main/java/com/notdo/util_ui/component/TextField.kt
@@ -148,6 +148,7 @@ fun NotDoTextField(
     }
 }
 
+@OptIn(ExperimentalTextApi::class)
 @Composable
 fun EmailCodeCheckTextField(
     text: String,
@@ -192,17 +193,36 @@ fun EmailCodeCheckTextField(
                 errorBorderColor = Color.Transparent
             ),
             placeholder = {
-                NotDoFont.Body(
+                Text(
                     text = "4자리 숫자를 입력해 주세요.",
-                    fontWeight = FontWeight.Normal,
-                    color = NotDoColor.Gray400
+                    style = TextStyle(
+                        fontFamily = pretendardFamily,
+                        fontWeight = FontWeight.Normal,
+                        color = NotDoColor.Gray500,
+                        fontSize = 14.sp,
+                        lineHeight = 20.sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Center,
+                            trim = LineHeightStyle.Trim.FirstLineTop
+                        ),
+                        platformStyle = PlatformTextStyle(
+                            false
+                        )
+                    )
                 )
             },
             textStyle = TextStyle(
                 fontFamily = pretendardFamily,
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.sp,
-                lineHeight = 20.sp
+                lineHeight = 20.sp,
+                lineHeightStyle = LineHeightStyle(
+                    alignment = LineHeightStyle.Alignment.Center,
+                    trim = LineHeightStyle.Trim.FirstLineTop
+                ),
+                platformStyle = PlatformTextStyle(
+                    false
+                )
             ),
             keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
             singleLine = true,


### PR DESCRIPTION
## PR 정보
-  비번찾기의 이메일 인증 페이지 구현

## 작업 내용
- 비변찾기의 이메일 인증 UI를 구현했습니다.
- 이메일 인증 텍스트필드의 lineheight가 맞지 않던 문제를 수정했습니다.
- 재전송 버튼을 눌러도 에러가 사라지지 않던 문제를 수정했습니다.

## 작업 결과
https://github.com/NotDo/NotDo-AOS/assets/80810303/6d10d91d-8503-4bf2-8d38-9b7b9c37402e

https://github.com/NotDo/NotDo-AOS/assets/80810303/2869e562-b7a2-45a5-b3d7-86da7a674a35

## 추가사항
- 디자이너와 이야기 후 UI변경 필요
